### PR TITLE
Add geometry structures and collision tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
+        "@types/node": "^20.12.7",
         "@typescript-eslint/eslint-plugin": "^8.43.0",
         "@typescript-eslint/parser": "^8.43.0",
         "eslint": "^8.57.1",
@@ -284,14 +285,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.4.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.4.0.tgz",
-      "integrity": "sha512-gUuVEAK4/u6F9wRLznPUU4WGUacSEBDPoC2TrBkw3GAnOLHBL45QdfHOXp1kJ4ypBGLxTOB+t7NJLpKoC3gznQ==",
+      "version": "20.19.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.14.tgz",
+      "integrity": "sha512-gqiKWld3YIkmtrrg9zDvg9jfksZCcPywXVN7IauUGhilwGV/yOyeUsvpR796m/Jye0zUzMXPKe8Ct1B79A7N5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "undici-types": "~7.11.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1882,12 +1882,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.11.0.tgz",
-      "integrity": "sha512-kt1ZriHTi7MU+Z/r9DOdAI3ONdaR3M3csEaRc6ewa4f4dTvX4cQCbJ4NkEn0ohE4hHtq85+PhPSTY+pO/1PwgA==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test -r ts-node/register tests/geometry.spec.ts",
     "build": "tsc",
     "lint": "eslint . --ext .ts"
   },
@@ -13,6 +13,7 @@
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
+    "@types/node": "^20.12.7",
     "@typescript-eslint/eslint-plugin": "^8.43.0",
     "@typescript-eslint/parser": "^8.43.0",
     "eslint": "^8.57.1",

--- a/src/geometry/room.ts
+++ b/src/geometry/room.ts
@@ -1,0 +1,61 @@
+export interface Point {
+  x: number;
+  y: number;
+}
+
+interface BaseElement {
+  start: Point;
+  end: Point;
+  height: number;
+  thickness: number;
+}
+
+export type Wall = BaseElement;
+
+export type Opening = BaseElement;
+
+export interface Room extends BaseElement {
+  walls: Wall[];
+  openings: Opening[];
+}
+
+export function wallLength(wall: Wall): number {
+  const dx = wall.end.x - wall.start.x;
+  const dy = wall.end.y - wall.start.y;
+  return Math.hypot(dx, dy);
+}
+
+function orientation(p: Point, q: Point, r: Point): number {
+  const val = (q.y - p.y) * (r.x - q.x) - (q.x - p.x) * (r.y - q.y);
+  if (val === 0) return 0;
+  return val > 0 ? 1 : 2;
+}
+
+function onSegment(p: Point, q: Point, r: Point): boolean {
+  return (
+    q.x <= Math.max(p.x, r.x) &&
+    q.x >= Math.min(p.x, r.x) &&
+    q.y <= Math.max(p.y, r.y) &&
+    q.y >= Math.min(p.y, r.y)
+  );
+}
+
+export function checkCollision(a: BaseElement, b: BaseElement): boolean {
+  const o1 = orientation(a.start, a.end, b.start);
+  const o2 = orientation(a.start, a.end, b.end);
+  const o3 = orientation(b.start, b.end, a.start);
+  const o4 = orientation(b.start, b.end, a.end);
+
+  if (o1 !== o2 && o3 !== o4) return true;
+
+  if (o1 === 0 && onSegment(a.start, b.start, a.end)) return true;
+  if (o2 === 0 && onSegment(a.start, b.end, a.end)) return true;
+  if (o3 === 0 && onSegment(b.start, a.start, b.end)) return true;
+  if (o4 === 0 && onSegment(b.start, a.end, b.end)) return true;
+
+  return false;
+}
+
+export function convertToLocal(point: Point, origin: Point): Point {
+  return { x: point.x - origin.x, y: point.y - origin.y };
+}

--- a/tests/geometry.spec.ts
+++ b/tests/geometry.spec.ts
@@ -1,0 +1,45 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { Wall, checkCollision, wallLength } from '../src/geometry/room';
+
+test('calculates wall length', () => {
+  const wall: Wall = {
+    start: { x: 0, y: 0 },
+    end: { x: 3, y: 4 },
+    height: 2.5,
+    thickness: 0.2,
+  };
+  assert.strictEqual(wallLength(wall), 5);
+});
+
+test('detects collision between walls', () => {
+  const wall1: Wall = {
+    start: { x: 0, y: 0 },
+    end: { x: 10, y: 0 },
+    height: 2.5,
+    thickness: 0.2,
+  };
+  const wall2: Wall = {
+    start: { x: 5, y: -5 },
+    end: { x: 5, y: 5 },
+    height: 2.5,
+    thickness: 0.2,
+  };
+  assert.ok(checkCollision(wall1, wall2));
+});
+
+test('detects lack of collision between walls', () => {
+  const wall1: Wall = {
+    start: { x: 0, y: 0 },
+    end: { x: 1, y: 0 },
+    height: 2.5,
+    thickness: 0.2,
+  };
+  const wall2: Wall = {
+    start: { x: 2, y: 0 },
+    end: { x: 3, y: 0 },
+    height: 2.5,
+    thickness: 0.2,
+  };
+  assert.ok(!checkCollision(wall1, wall2));
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,14 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "ESNext",
+    "module": "CommonJS",
     "rootDir": "src",
     "outDir": "dist",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- implement Room, Wall, and Opening geometry with point-based coordinates
- add helpers for wall length, collision detection, and coordinate translation
- cover geometry helpers with unit tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7c7cb9be483228160111f06ccf3d5