### PR TITLE
Implement cabinet placement algorithm and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node --test -r ts-node/register tests/geometry.spec.ts",
+    "test": "node --test -r ts-node/register tests/*.spec.ts",
     "build": "tsc",
     "lint": "eslint . --ext .ts"
   },

--- a/src/layout/placement.ts
+++ b/src/layout/placement.ts
@@ -1,0 +1,75 @@
+import { Room, Wall, Point, wallLength, checkCollision, convertToLocal } from '../geometry/room';
+
+export interface Module {
+  width: number;
+  height?: number;
+}
+
+export interface PlacedModule extends Module {
+  x: number;
+  y: number;
+}
+
+export const SPACING = 0.05; // default gap in meters
+
+function projectToWall(point: Point, wall: Wall): number {
+  const local = convertToLocal(point, wall.start);
+  if (wall.start.x === wall.end.x) {
+    return local.y;
+  }
+  if (wall.start.y === wall.end.y) {
+    return local.x;
+  }
+  const dx = wall.end.x - wall.start.x;
+  const dy = wall.end.y - wall.start.y;
+  const len = Math.hypot(dx, dy);
+  return (local.x * dx + local.y * dy) / len;
+}
+
+export function placeCabinets(room: Room, wallId: number, modules: Module[]): PlacedModule[] {
+  const wall = room.walls[wallId];
+  if (!wall) throw new Error('Wall not found');
+
+  const sorted = [...modules].sort((a, b) => b.width - a.width);
+  const totalWidth = sorted.reduce((sum, m) => sum + m.width, 0);
+  const totalSpacing = SPACING * (sorted.length + 1);
+  const length = wallLength(wall);
+
+  if (totalWidth + totalSpacing > length) {
+    throw new Error('Modules exceed wall length');
+  }
+
+  const openings = room.openings
+    .filter((o) => checkCollision(o, wall))
+    .map((o) => {
+      const start = projectToWall(o.start, wall);
+      const end = projectToWall(o.end, wall);
+      return [Math.min(start, end), Math.max(start, end)];
+    });
+
+  let cursor = SPACING;
+  const placed: PlacedModule[] = [];
+  for (const mod of sorted) {
+    let start = cursor;
+    let end = start + mod.width;
+    let adjusted = true;
+    while (adjusted) {
+      adjusted = false;
+      for (const [os, oe] of openings) {
+        if (start < oe && end > os) {
+          start = oe + SPACING;
+          end = start + mod.width;
+          adjusted = true;
+          break;
+        }
+      }
+    }
+    if (end > length - SPACING) {
+      throw new Error('Not enough space for modules');
+    }
+    placed.push({ ...mod, x: start, y: 0 });
+    cursor = end + SPACING;
+  }
+
+  return placed;
+}

--- a/tests/placement.spec.ts
+++ b/tests/placement.spec.ts
@@ -1,0 +1,80 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { Room, Wall, Opening } from '../src/geometry/room';
+import { placeCabinets, SPACING, Module } from '../src/layout/placement';
+
+test('places modules on a simple wall', () => {
+  const wall: Wall = {
+    start: { x: 0, y: 0 },
+    end: { x: 5, y: 0 },
+    height: 2.5,
+    thickness: 0.2,
+  };
+  const room: Room = {
+    start: { x: 0, y: 0 },
+    end: { x: 0, y: 0 },
+    height: 0,
+    thickness: 0,
+    walls: [wall],
+    openings: [],
+  };
+  const modules: Module[] = [
+    { width: 0.5 },
+    { width: 1 },
+    { width: 0.75 },
+  ];
+  const placed = placeCabinets(room, 0, modules);
+  assert.deepStrictEqual(placed.map((m) => m.width), [1, 0.75, 0.5]);
+  const expectedPositions = [
+    SPACING,
+    1 + 2 * SPACING,
+    1 + 0.75 + 3 * SPACING,
+  ];
+  const rounded = placed.map((m) => Number(m.x.toFixed(10)));
+  assert.deepStrictEqual(rounded, expectedPositions);
+});
+
+test('skips openings when placing modules', () => {
+  const wall: Wall = {
+    start: { x: 0, y: 0 },
+    end: { x: 5, y: 0 },
+    height: 2.5,
+    thickness: 0.2,
+  };
+  const window: Opening = {
+    start: { x: 2, y: 0 },
+    end: { x: 3, y: 0 },
+    height: 1.2,
+    thickness: 0.1,
+  };
+  const room: Room = {
+    start: { x: 0, y: 0 },
+    end: { x: 0, y: 0 },
+    height: 0,
+    thickness: 0,
+    walls: [wall],
+    openings: [window],
+  };
+  const modules: Module[] = [{ width: 1 }, { width: 1 }];
+  const placed = placeCabinets(room, 0, modules);
+  assert.strictEqual(placed[1].x, 3 + SPACING);
+});
+
+test('throws error when modules exceed wall length', () => {
+  const wall: Wall = {
+    start: { x: 0, y: 0 },
+    end: { x: 2, y: 0 },
+    height: 2.5,
+    thickness: 0.2,
+  };
+  const room: Room = {
+    start: { x: 0, y: 0 },
+    end: { x: 0, y: 0 },
+    height: 0,
+    thickness: 0,
+    walls: [wall],
+    openings: [],
+  };
+  const modules: Module[] = [{ width: 1 }, { width: 1 }];
+  assert.throws(() => placeCabinets(room, 0, modules));
+});


### PR DESCRIPTION
## Summary
- add `placeCabinets` with spacing, sorting, and opening collision handling
- validate cabinet widths against wall length
- cover placement scenarios with new unit tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7ca45e9dc8322a124b5a76a53c11b