### PR TITLE
Add cutlist utilities and tests

### DIFF
--- a/src/cutlist/format.ts
+++ b/src/cutlist/format.ts
@@ -1,0 +1,59 @@
+export interface Part {
+  width: number;
+  height: number;
+}
+
+export interface PlacedPart extends Part {
+  x: number;
+  y: number;
+  sheet: number;
+}
+
+export interface Sheet {
+  width: number;
+  height: number;
+}
+
+export function validateParts(parts: Part[], sheet: Sheet): void {
+  for (const part of parts) {
+    if (part.width > sheet.width || part.height > sheet.height) {
+      throw new Error('Part exceeds sheet dimensions');
+    }
+  }
+}
+
+export function packGuillotine(parts: Part[], sheet: Sheet): PlacedPart[] {
+  validateParts(parts, sheet);
+  const sorted = [...parts].sort((a, b) => b.height - a.height);
+  const placed: PlacedPart[] = [];
+  let x = 0;
+  let y = 0;
+  let rowHeight = 0;
+  let sheetIndex = 0;
+
+  for (const part of sorted) {
+    if (x + part.width > sheet.width) {
+      x = 0;
+      y += rowHeight;
+      rowHeight = 0;
+    }
+    if (y + part.height > sheet.height) {
+      sheetIndex++;
+      x = 0;
+      y = 0;
+      rowHeight = 0;
+    }
+    placed.push({ ...part, x, y, sheet: sheetIndex });
+    x += part.width;
+    if (part.height > rowHeight) {
+      rowHeight = part.height;
+    }
+  }
+  return placed;
+}
+
+import { Module } from '../layout/placement';
+
+export function modulesToParts(modules: Module[]): Part[] {
+  return modules.map((m) => ({ width: m.width, height: m.height ?? m.width }));
+}

--- a/tests/cutlist.spec.ts
+++ b/tests/cutlist.spec.ts
@@ -1,0 +1,42 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { modulesToParts, packGuillotine, validateParts, Sheet } from '../src/cutlist/format';
+import { Module } from '../src/layout/placement';
+
+test('packs parts within a single sheet', () => {
+  const modules: Module[] = [
+    { width: 60, height: 40 },
+    { width: 60, height: 60 },
+    { width: 40, height: 40 },
+  ];
+  const parts = modulesToParts(modules);
+  const sheet: Sheet = { width: 100, height: 100 };
+  validateParts(parts, sheet);
+  const placed = packGuillotine(parts, sheet);
+  assert.strictEqual(Math.max(...placed.map((p) => p.sheet)) + 1, 1);
+  const coords = placed.map((p) => ({ sheet: p.sheet, x: p.x, y: p.y, width: p.width, height: p.height }));
+  assert.deepStrictEqual(coords, [
+    { sheet: 0, x: 0, y: 0, width: 60, height: 60 },
+    { sheet: 0, x: 0, y: 60, width: 60, height: 40 },
+    { sheet: 0, x: 60, y: 60, width: 40, height: 40 },
+  ]);
+});
+
+test('uses multiple sheets when necessary', () => {
+  const modules: Module[] = [
+    { width: 80, height: 60 },
+    { width: 80, height: 60 },
+    { width: 20, height: 30 },
+  ];
+  const parts = modulesToParts(modules);
+  const sheet: Sheet = { width: 100, height: 100 };
+  validateParts(parts, sheet);
+  const placed = packGuillotine(parts, sheet);
+  assert.strictEqual(Math.max(...placed.map((p) => p.sheet)) + 1, 2);
+  const coords = placed.map((p) => ({ sheet: p.sheet, x: p.x, y: p.y }));
+  assert.deepStrictEqual(coords, [
+    { sheet: 0, x: 0, y: 0 },
+    { sheet: 1, x: 0, y: 0 },
+    { sheet: 1, x: 80, y: 0 },
+  ]);
+});


### PR DESCRIPTION
## Summary
- add `validateParts` and `packGuillotine` helpers with `modulesToParts` conversion
- support converting layout modules to cutlist parts
- test guillotine packing for sheet count and placement

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7cb6b778083229f4e6113fc86fda9