### PR TITLE
feat: add animated top menu component

### DIFF
--- a/web/src/components/TopMenu.css
+++ b/web/src/components/TopMenu.css
@@ -1,0 +1,37 @@
+.top-menu {
+  display: flex;
+  gap: 1rem;
+}
+
+.menu-link {
+  position: relative;
+  text-decoration: none;
+  color: #333;
+  padding: 4px 0;
+  transition: color 0.3s;
+}
+
+.menu-link::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: -2px;
+  width: 100%;
+  height: 2px;
+  background: currentColor;
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.3s;
+}
+
+.menu-link:hover {
+  color: #007bff;
+}
+
+.menu-link.active {
+  color: #007bff;
+}
+
+.menu-link.active::after {
+  transform: scaleX(1);
+}

--- a/web/src/components/TopMenu.tsx
+++ b/web/src/components/TopMenu.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react'
+import './TopMenu.css'
+
+const tabs = [
+  { id: 'home', label: 'Home' },
+  { id: 'projects', label: 'Projects' },
+  { id: 'about', label: 'About' },
+]
+
+export default function TopMenu() {
+  const [active, setActive] = useState('home')
+
+  return (
+    <nav className="top-menu">
+      {tabs.map((tab) => (
+        <a
+          key={tab.id}
+          href="#"
+          className={`menu-link ${active === tab.id ? 'active' : ''}`}
+          onClick={(e) => {
+            e.preventDefault()
+            setActive(tab.id)
+          }}
+        >
+          {tab.label}
+        </a>
+      ))}
+    </nav>
+  )
+}


### PR DESCRIPTION
## Summary
- add `TopMenu` navigation component with active tab state
- style menu links with CSS transitions for animated underline

## Testing
- `npm test`
- `npm --prefix web run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7d3bf6e8c8322825312aa73689f3c