### PR TITLE
feat: add viewer component with view menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,16 @@
+import React, { useState } from 'react';
+import ViewMenu, { View } from './components/ViewMenu';
+import Viewer from './components/Viewer';
+
+const App: React.FC = () => {
+  const [currentView, setCurrentView] = useState<View>('3d');
+
+  return (
+    <div>
+      <ViewMenu currentView={currentView} onViewChange={setCurrentView} />
+      <Viewer currentView={currentView} />
+    </div>
+  );
+};
+
+export default App;

--- a/src/components/ViewMenu.tsx
+++ b/src/components/ViewMenu.tsx
@@ -1,7 +1,13 @@
-import React, { useState } from 'react';
-import { mdiViewGrid, mdiViewAgenda, mdiCubeOutline } from '@mdi/js';
+import React from 'react';
+import {
+  mdiCubeOutline,
+  mdiArrowUp,
+  mdiArrowDown,
+  mdiArrowLeft,
+  mdiArrowRight,
+} from '@mdi/js';
 
-export type View = 'grid' | 'list' | '3d';
+export type View = '3d' | 'top' | 'back' | 'left' | 'right';
 
 interface ViewInfo {
   id: View;
@@ -10,14 +16,18 @@ interface ViewInfo {
 }
 
 const views: ViewInfo[] = [
-  { id: 'grid', icon: mdiViewGrid, title: 'Grid view' },
-  { id: 'list', icon: mdiViewAgenda, title: 'List view' },
   { id: '3d', icon: mdiCubeOutline, title: '3D view' },
+  { id: 'top', icon: mdiArrowUp, title: 'Top view' },
+  { id: 'back', icon: mdiArrowDown, title: 'Back view' },
+  { id: 'left', icon: mdiArrowLeft, title: 'Left view' },
+  { id: 'right', icon: mdiArrowRight, title: 'Right view' },
 ];
+interface ViewMenuProps {
+  currentView: View;
+  onViewChange: (view: View) => void;
+}
 
-export const ViewMenu: React.FC = () => {
-  const [currentView, setCurrentView] = useState<View>('grid');
-
+export const ViewMenu: React.FC<ViewMenuProps> = ({ currentView, onViewChange }) => {
   return (
     <div style={{ display: 'flex', gap: '0.5rem' }}>
       {views.map(({ id, icon, title }) => (
@@ -26,7 +36,7 @@ export const ViewMenu: React.FC = () => {
           width="24"
           height="24"
           viewBox="0 0 24 24"
-          onClick={() => setCurrentView(id)}
+          onClick={() => onViewChange(id)}
           style={{
             cursor: 'pointer',
             fill: currentView === id ? '#1976d2' : '#777',

--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import type { View } from './ViewMenu';
+
+interface ViewerProps {
+  currentView: View;
+}
+
+const Viewer: React.FC<ViewerProps> = ({ currentView }) => {
+  switch (currentView) {
+    case '3d':
+      return <canvas data-testid="view-3d" />;
+    case 'top':
+      return <div data-testid="view-top">Top view placeholder</div>;
+    case 'back':
+      return <div data-testid="view-back">Back view placeholder</div>;
+    case 'left':
+      return <div data-testid="view-left">Left view placeholder</div>;
+    case 'right':
+      return <div data-testid="view-right">Right view placeholder</div>;
+    default:
+      return null;
+  }
+};
+
+export default Viewer;


### PR DESCRIPTION
## Summary
- add Viewer component with placeholders for 3D and orthographic views
- refactor ViewMenu to accept parent state and expose 3D/top/back/left/right views
- connect ViewMenu and Viewer in App component through shared state

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7d78be45883228e5a3a9b46f62826