### PR TITLE
feat: rename top menu tabs

### DIFF
--- a/web/src/components/TopMenu.tsx
+++ b/web/src/components/TopMenu.tsx
@@ -2,13 +2,14 @@ import { useState } from 'react'
 import './TopMenu.css'
 
 const tabs = [
-  { id: 'home', label: 'Home' },
-  { id: 'projects', label: 'Projects' },
-  { id: 'about', label: 'About' },
+  { id: 'szafki', label: 'Szafki' },
+  { id: 'pomieszczenie', label: 'Pomieszczenie' },
+  { id: 'koszt', label: 'Koszt' },
+  { id: 'formatki', label: 'Formatki' },
 ]
 
 export default function TopMenu() {
-  const [active, setActive] = useState('home')
+  const [active, setActive] = useState('szafki')
 
   return (
     <nav className="top-menu">


### PR DESCRIPTION
## Summary
- rename top menu tabs to Szafki, Pomieszczenie, Koszt, Formatki
- set Szafki as default active tab

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7e53067b883228537f8d8e4e5c34c