### PR TITLE
feat: add view menu component with icons

### DIFF
--- a/web/src/assets/back-view.svg
+++ b/web/src/assets/back-view.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 19V5"/>
+  <path d="M19 12l-7-7-7 7"/>
+</svg>

--- a/web/src/assets/left-view.svg
+++ b/web/src/assets/left-view.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M15 5l-7 7 7 7"/>
+</svg>

--- a/web/src/assets/right-view.svg
+++ b/web/src/assets/right-view.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M9 5l7 7-7 7"/>
+</svg>

--- a/web/src/assets/top-view.svg
+++ b/web/src/assets/top-view.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 5v14"/>
+  <path d="M5 12l7 7 7-7"/>
+</svg>

--- a/web/src/assets/view-3d.svg
+++ b/web/src/assets/view-3d.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 7l9-4 9 4-9 4-9-4z"/>
+  <path d="M3 7v10l9 4 9-4V7"/>
+  <path d="M12 11v10"/>
+</svg>

--- a/web/src/components/ViewMenu.css
+++ b/web/src/components/ViewMenu.css
@@ -1,0 +1,28 @@
+.view-menu {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.view-button {
+  background: none;
+  border: none;
+  padding: 4px;
+  cursor: pointer;
+  opacity: 0.6;
+  transition: opacity 0.3s, border-color 0.3s;
+  border-bottom: 2px solid transparent;
+}
+
+.view-button img {
+  width: 24px;
+  height: 24px;
+}
+
+.view-button:hover {
+  opacity: 0.8;
+}
+
+.view-button.active {
+  opacity: 1;
+  border-bottom-color: #007bff;
+}

--- a/web/src/components/ViewMenu.tsx
+++ b/web/src/components/ViewMenu.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react'
+import './ViewMenu.css'
+
+import view3dIcon from '../assets/view-3d.svg'
+import topIcon from '../assets/top-view.svg'
+import backIcon from '../assets/back-view.svg'
+import leftIcon from '../assets/left-view.svg'
+import rightIcon from '../assets/right-view.svg'
+
+const views = [
+  { id: '3d', label: 'widok 3D', icon: view3dIcon },
+  { id: 'top', label: 'rzut z góry 2D', icon: topIcon },
+  { id: 'back', label: 'rzut z tyłu 2D', icon: backIcon },
+  { id: 'left', label: 'rzut z lewego boku 2D', icon: leftIcon },
+  { id: 'right', label: 'rzut z prawego boku 2D', icon: rightIcon },
+]
+
+export default function ViewMenu() {
+  const [active, setActive] = useState('3d')
+
+  return (
+    <nav className="view-menu">
+      {views.map((view) => (
+        <button
+          key={view.id}
+          className={`view-button ${active === view.id ? 'active' : ''}`}
+          onClick={() => setActive(view.id)}
+        >
+          <img src={view.icon} alt={view.label} />
+        </button>
+      ))}
+    </nav>
+  )
+}


### PR DESCRIPTION
## Summary
- add `ViewMenu` React component with 3D and 2D view icons
- style view menu for horizontal layout and active highlighting
- include SVG assets for view icons

## Testing
- `npm test`
- `npm run lint`
- `npm --prefix web run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7e7e712d88322ab9ed053718e0540