### PR TITLE
Add viewer component with view placeholders

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,33 +1,21 @@
 import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
 import './App.css'
+import Viewer, { View } from './components/Viewer'
 
 function App() {
-  const [count, setCount] = useState(0)
+  const views: View[] = ['3d', 'top', 'back', 'left', 'right']
+  const [currentView, setCurrentView] = useState<View>('3d')
 
   return (
     <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
+      <Viewer currentView={currentView} />
+      <div className="view-controls">
+        {views.map((view) => (
+          <button key={view} onClick={() => setCurrentView(view)}>
+            {view}
+          </button>
+        ))}
       </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
     </>
   )
 }

--- a/web/src/components/Viewer.tsx
+++ b/web/src/components/Viewer.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+
+export type View = '3d' | 'top' | 'back' | 'left' | 'right'
+
+interface ViewerProps {
+  currentView: View
+}
+
+export default function Viewer({ currentView }: ViewerProps) {
+  switch (currentView) {
+    case '3d':
+      return <canvas data-testid="view-3d">3D view placeholder</canvas>
+    case 'top':
+      return <div data-testid="view-top">Top view placeholder</div>
+    case 'back':
+      return <div data-testid="view-back">Back view placeholder</div>
+    case 'left':
+      return <div data-testid="view-left">Left view placeholder</div>
+    case 'right':
+      return <div data-testid="view-right">Right view placeholder</div>
+    default:
+      return null
+  }
+}


### PR DESCRIPTION
## Summary
- add `Viewer` component rendering placeholders for 3D and 2D views
- integrate viewer into `App` with simple controls to switch between views

## Testing
- `npm test`
- `npm --prefix web run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7eb34919083229825dec745ab612d