### PR TITLE
feat(web): integrate menus with shared state

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1,42 +1,17 @@
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  width: 100vw;
+  height: 100vh;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.app {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  height: 100%;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+.viewer {
+  flex: 1;
+  align-self: stretch;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
-}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,22 +1,21 @@
 import { useState } from 'react'
 import './App.css'
+import TopMenu from './components/TopMenu'
+import ViewMenu from './components/ViewMenu'
 import Viewer, { View } from './components/Viewer'
 
 function App() {
-  const views: View[] = ['3d', 'top', 'back', 'left', 'right']
+  const [activeTab, setActiveTab] = useState('szafki')
   const [currentView, setCurrentView] = useState<View>('3d')
 
   return (
-    <>
-      <Viewer currentView={currentView} />
-      <div className="view-controls">
-        {views.map((view) => (
-          <button key={view} onClick={() => setCurrentView(view)}>
-            {view}
-          </button>
-        ))}
+    <div className="app">
+      <TopMenu activeTab={activeTab} setActiveTab={setActiveTab} />
+      <ViewMenu currentView={currentView} setCurrentView={setCurrentView} />
+      <div className="viewer">
+        <Viewer currentView={currentView} />
       </div>
-    </>
+    </div>
   )
 }
 

--- a/web/src/components/TopMenu.tsx
+++ b/web/src/components/TopMenu.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import './TopMenu.css'
 
 const tabs = [
@@ -8,19 +7,22 @@ const tabs = [
   { id: 'formatki', label: 'Formatki' },
 ]
 
-export default function TopMenu() {
-  const [active, setActive] = useState('szafki')
+interface TopMenuProps {
+  activeTab: string
+  setActiveTab: (id: string) => void
+}
 
+export default function TopMenu({ activeTab, setActiveTab }: TopMenuProps) {
   return (
     <nav className="top-menu">
       {tabs.map((tab) => (
         <a
           key={tab.id}
           href="#"
-          className={`menu-link ${active === tab.id ? 'active' : ''}`}
+          className={`menu-link ${activeTab === tab.id ? 'active' : ''}`}
           onClick={(e) => {
             e.preventDefault()
-            setActive(tab.id)
+            setActiveTab(tab.id)
           }}
         >
           {tab.label}

--- a/web/src/components/ViewMenu.tsx
+++ b/web/src/components/ViewMenu.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import './ViewMenu.css'
 
 import view3dIcon from '../assets/view-3d.svg'
@@ -7,7 +6,9 @@ import backIcon from '../assets/back-view.svg'
 import leftIcon from '../assets/left-view.svg'
 import rightIcon from '../assets/right-view.svg'
 
-const views = [
+import { View } from './Viewer'
+
+const views: { id: View; label: string; icon: string }[] = [
   { id: '3d', label: 'widok 3D', icon: view3dIcon },
   { id: 'top', label: 'rzut z góry 2D', icon: topIcon },
   { id: 'back', label: 'rzut z tyłu 2D', icon: backIcon },
@@ -15,16 +16,19 @@ const views = [
   { id: 'right', label: 'rzut z prawego boku 2D', icon: rightIcon },
 ]
 
-export default function ViewMenu() {
-  const [active, setActive] = useState('3d')
+interface ViewMenuProps {
+  currentView: View
+  setCurrentView: (view: View) => void
+}
 
+export default function ViewMenu({ currentView, setCurrentView }: ViewMenuProps) {
   return (
     <nav className="view-menu">
       {views.map((view) => (
         <button
           key={view.id}
-          className={`view-button ${active === view.id ? 'active' : ''}`}
-          onClick={() => setActive(view.id)}
+          className={`view-button ${currentView === view.id ? 'active' : ''}`}
+          onClick={() => setCurrentView(view.id)}
         >
           <img src={view.icon} alt={view.label} />
         </button>


### PR DESCRIPTION
## Summary
- integrate TopMenu, ViewMenu, and Viewer in App with shared `activeTab` and `currentView`
- align TopMenu above ViewMenu and viewer using new layout styles
- add flex-based CSS so menus stay top-left and viewer stretches to fill

## Testing
- `npm test`
- `npm run lint`
- `cd web && npm test` *(fails: Missing script: "test")*
- `cd web && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7ec95ea188322b49069fd7edd1521