### PR TITLE
Improve menu styling and layout responsiveness

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -3,15 +3,16 @@
   height: 100vh;
 }
 
+
 .app {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
+  display: grid;
+  grid-template-rows: auto auto 1fr;
   height: 100%;
+  width: 100%;
 }
 
 .viewer {
-  flex: 1;
-  align-self: stretch;
+  width: 100%;
+  height: 100%;
 }
 

--- a/web/src/components/TopMenu.css
+++ b/web/src/components/TopMenu.css
@@ -1,5 +1,7 @@
 .top-menu {
   display: flex;
+  justify-content: flex-start;
+  align-items: center;
   gap: 1rem;
 }
 
@@ -8,7 +10,7 @@
   text-decoration: none;
   color: #333;
   padding: 4px 0;
-  transition: color 0.3s;
+  transition: color 0.3s ease;
 }
 
 .menu-link::after {
@@ -21,7 +23,7 @@
   background: currentColor;
   transform: scaleX(0);
   transform-origin: left;
-  transition: transform 0.3s;
+  transition: transform 0.3s ease;
 }
 
 .menu-link:hover {

--- a/web/src/components/ViewMenu.css
+++ b/web/src/components/ViewMenu.css
@@ -1,6 +1,6 @@
 .view-menu {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.75rem;
 }
 
 .view-button {
@@ -9,8 +9,8 @@
   padding: 4px;
   cursor: pointer;
   opacity: 0.6;
-  transition: opacity 0.3s, border-color 0.3s;
   border-bottom: 2px solid transparent;
+  transition: opacity 0.3s ease, transform 0.3s ease, border-bottom-color 0.3s ease;
 }
 
 .view-button img {
@@ -19,7 +19,8 @@
 }
 
 .view-button:hover {
-  opacity: 0.8;
+  opacity: 1;
+  transform: translateY(-2px);
 }
 
 .view-button.active {


### PR DESCRIPTION
## Summary
- align top navigation to the left and smooth its hover/active animations
- add spacing, hover effects, and active highlight for view icon menu
- switch app layout to grid so menus stack and viewer fills remaining space

## Testing
- `npm test`
- `npm run lint`
- `cd web && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7ed98fa5883229303a6b8403f4adb