### PR TITLE
feat: configure base path

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -3,6 +3,8 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
-  base: '/MebloPlaner/',
+  base:
+    process.env.VITE_BASE_URL ??
+    (process.env.NODE_ENV === 'production' ? '/MebloPlaner/' : '/'),
   plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- configure Vite base path using NODE_ENV and optional `VITE_BASE_URL`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7f4000ae48322a06a9eff4e3c8606