### PR TITLE
Switch top menu tabs to buttons

### DIFF
--- a/web/src/components/TopMenu.css
+++ b/web/src/components/TopMenu.css
@@ -5,15 +5,17 @@
   gap: 1rem;
 }
 
-.menu-link {
+.menu-button {
   position: relative;
-  text-decoration: none;
+  background: none;
+  border: none;
+  cursor: pointer;
   color: #333;
   padding: 4px 0;
   transition: color 0.3s ease;
 }
 
-.menu-link::after {
+.menu-button::after {
   content: '';
   position: absolute;
   left: 0;
@@ -26,14 +28,14 @@
   transition: transform 0.3s ease;
 }
 
-.menu-link:hover {
+.menu-button:hover {
   color: #007bff;
 }
 
-.menu-link.active {
+.menu-button.active {
   color: #007bff;
 }
 
-.menu-link.active::after {
+.menu-button.active::after {
   transform: scaleX(1);
 }

--- a/web/src/components/TopMenu.tsx
+++ b/web/src/components/TopMenu.tsx
@@ -16,17 +16,16 @@ export default function TopMenu({ activeTab, setActiveTab }: TopMenuProps) {
   return (
     <nav className="top-menu">
       {tabs.map((tab) => (
-        <a
+        <button
           key={tab.id}
-          href="#"
-          className={`menu-link ${activeTab === tab.id ? 'active' : ''}`}
-          onClick={(e) => {
-            e.preventDefault()
+          type="button"
+          className={`menu-button ${activeTab === tab.id ? 'active' : ''}`}
+          onClick={() => {
             setActiveTab(tab.id)
           }}
         >
           {tab.label}
-        </a>
+        </button>
       ))}
     </nav>
   )


### PR DESCRIPTION
## Summary
- replace anchor tags with buttons for tab selection in top menu
- style new buttons to match previous link appearance

## Testing
- `npm test`
- `npm --prefix web run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7f6c3cbf88322a89586cf64a45b56