### PR TITLE
Add accessible labels to view menu buttons

### DIFF
--- a/web/src/components/ViewMenu.tsx
+++ b/web/src/components/ViewMenu.tsx
@@ -29,8 +29,9 @@ export default function ViewMenu({ currentView, setCurrentView }: ViewMenuProps)
           key={view.id}
           className={`view-button ${currentView === view.id ? 'active' : ''}`}
           onClick={() => setCurrentView(view.id)}
+          aria-label={view.label}
         >
-          <img src={view.icon} alt={view.label} />
+          <img src={view.icon} alt="" aria-hidden="true" />
         </button>
       ))}
     </nav>


### PR DESCRIPTION
## Summary
- ensure each view menu button is announced by screen readers by wiring `aria-label` to the view label
- hide decorative icons from assistive tech with empty `alt` and `aria-hidden`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7f75325a48322a94c6645b98f87d2