### PR TITLE
Validate positive part dimensions in cutlist

### DIFF
--- a/src/cutlist/format.ts
+++ b/src/cutlist/format.ts
@@ -16,6 +16,9 @@ export interface Sheet {
 
 export function validateParts(parts: Part[], sheet: Sheet): void {
   for (const part of parts) {
+    if (part.width <= 0 || part.height <= 0) {
+      throw new Error('Part dimensions must be positive');
+    }
     if (part.width > sheet.width || part.height > sheet.height) {
       throw new Error('Part exceeds sheet dimensions');
     }

--- a/tests/cutlist.spec.ts
+++ b/tests/cutlist.spec.ts
@@ -40,3 +40,15 @@ test('uses multiple sheets when necessary', () => {
     { sheet: 1, x: 80, y: 0 },
   ]);
 });
+
+test('throws error for non-positive part dimensions', () => {
+  const sheet: Sheet = { width: 100, height: 100 };
+  assert.throws(
+    () => validateParts([{ width: 0, height: 10 }], sheet),
+    /Part dimensions must be positive/
+  );
+  assert.throws(
+    () => validateParts([{ width: 10, height: -5 }], sheet),
+    /Part dimensions must be positive/
+  );
+});


### PR DESCRIPTION
## Summary
- ensure parts have positive width and height before validating against sheet size
- add unit test for invalid part dimensions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7f82e0f048322bdcb897191b00b8f