### PR TITLE
feat: add exhaustiveness check to viewer

### DIFF
--- a/web/src/components/Viewer.tsx
+++ b/web/src/components/Viewer.tsx
@@ -2,6 +2,10 @@ import React from 'react'
 
 export type View = '3d' | 'top' | 'back' | 'left' | 'right'
 
+function assertNever(x: never): never {
+  throw new Error(`Unexpected view: ${x}`)
+}
+
 interface ViewerProps {
   currentView: View
 }
@@ -19,6 +23,6 @@ export default function Viewer({ currentView }: ViewerProps) {
     case 'right':
       return <div data-testid="view-right">Right view placeholder</div>
     default:
-      return null
+      return assertNever(currentView)
   }
 }


### PR DESCRIPTION
## Summary
- add assertNever helper to handle unexpected Viewer cases
- enforce exhaustive switch on view types

## Testing
- `npm test`
- `npm --prefix web run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7f9e1bc088322837abe37114fb138