### PR TITLE
Add top navigation tabs with placeholders

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -5,14 +5,29 @@
 
 
 .app {
-  display: grid;
-  grid-template-rows: auto auto 1fr;
+  display: flex;
+  flex-direction: column;
   height: 100%;
   width: 100%;
 }
 
+.content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
 .viewer {
+  flex: 1;
   width: 100%;
-  height: 100%;
+}
+
+.tab-placeholder {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  color: #666;
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,9 +11,24 @@ function App() {
   return (
     <div className="app">
       <TopMenu activeTab={activeTab} setActiveTab={setActiveTab} />
-      <ViewMenu currentView={currentView} setCurrentView={setCurrentView} />
-      <div className="viewer">
-        <Viewer currentView={currentView} />
+      <div className="content">
+        {activeTab === 'szafki' ? (
+          <>
+            <ViewMenu
+              currentView={currentView}
+              setCurrentView={setCurrentView}
+            />
+            <div className="viewer">
+              <Viewer currentView={currentView} />
+            </div>
+          </>
+        ) : (
+          <div className="tab-placeholder">
+            {activeTab === 'pomieszczenie' && 'Sekcja "Pomieszczenie" w przygotowaniu'}
+            {activeTab === 'koszt' && 'Sekcja "Koszt" w przygotowaniu'}
+            {activeTab === 'formatki' && 'Sekcja "Formatki" w przygotowaniu'}
+          </div>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- render TopMenu with conditional content for each tab
- adjust layout styles for flexible content area

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7fe6804d48322ad67204047098141