### PR TITLE
Use built index as entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,13 @@
   "name": "mebloplaner",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "dist/index.js",
   "scripts": {
     "test": "node --test -r ts-node/register tests/*.spec.ts",
     "build": "tsc",
     "lint": "eslint . --ext .ts",
-    "dev": "npm --prefix web run dev"
+    "dev": "npm --prefix web run dev",
+    "start": "node dist/index.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- point `main` at the compiled `dist/index.js`
- add `start` script to run the compiled entry

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c801c997a4832298005cc247a12110