### PR TITLE
refactor: rectangle-based collision

### DIFF
--- a/tests/geometry.spec.ts
+++ b/tests/geometry.spec.ts
@@ -28,6 +28,22 @@ test('detects collision between walls', () => {
   assert.ok(checkCollision(wall1, wall2));
 });
 
+test('detects collision between overlapping walls', () => {
+  const wall1: Wall = {
+    start: { x: 0, y: 0 },
+    end: { x: 5, y: 0 },
+    height: 2.5,
+    thickness: 1,
+  };
+  const wall2: Wall = {
+    start: { x: 0, y: 0.4 },
+    end: { x: 5, y: 0.4 },
+    height: 2.5,
+    thickness: 1,
+  };
+  assert.ok(checkCollision(wall1, wall2));
+});
+
 test('detects lack of collision between walls', () => {
   const wall1: Wall = {
     start: { x: 0, y: 0 },


### PR DESCRIPTION
## Summary
- model walls and openings as rectangles using thickness
- extend geometry tests to cover overlapping wall rectangles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c80db9638c8322aefb2aeb6b45a024