### PR TITLE
Respect original module ordering in cabinet placement

### DIFF
--- a/src/layout/placement.ts
+++ b/src/layout/placement.ts
@@ -30,9 +30,8 @@ export function placeCabinets(room: Room, wallId: number, modules: Module[]): Pl
   const wall = room.walls[wallId];
   if (!wall) throw new Error('Wall not found');
 
-  const sorted = [...modules].sort((a, b) => b.width - a.width);
-  const totalWidth = sorted.reduce((sum, m) => sum + m.width, 0);
-  const totalSpacing = SPACING * (sorted.length + 1);
+  const totalWidth = modules.reduce((sum, m) => sum + m.width, 0);
+  const totalSpacing = SPACING * (modules.length + 1);
   const length = wallLength(wall);
 
   if (totalWidth + totalSpacing > length) {
@@ -49,7 +48,7 @@ export function placeCabinets(room: Room, wallId: number, modules: Module[]): Pl
 
   let cursor = SPACING;
   const placed: PlacedModule[] = [];
-  for (const mod of sorted) {
+  for (const mod of modules) {
     let start = cursor;
     let end = start + mod.width;
     let adjusted = true;

--- a/tests/placement.spec.ts
+++ b/tests/placement.spec.ts
@@ -24,11 +24,11 @@ test('places modules on a simple wall', () => {
     { width: 0.75 },
   ];
   const placed = placeCabinets(room, 0, modules);
-  assert.deepStrictEqual(placed.map((m) => m.width), [1, 0.75, 0.5]);
+  assert.deepStrictEqual(placed.map((m) => m.width), [0.5, 1, 0.75]);
   const expectedPositions = [
     SPACING,
-    1 + 2 * SPACING,
-    1 + 0.75 + 3 * SPACING,
+    0.5 + 2 * SPACING,
+    0.5 + 1 + 3 * SPACING,
   ];
   const rounded = placed.map((m) => Number(m.x.toFixed(10)));
   assert.deepStrictEqual(rounded, expectedPositions);


### PR DESCRIPTION
## Summary
- Ensure `placeCabinets` processes modules in provided order instead of sorting by width
- Update placement tests to check the original ordering and expected positions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c8133179a08322a42dc50ef00d4ae8